### PR TITLE
Fix nil player ids

### DIFF
--- a/lib/elswisser/tournaments.ex
+++ b/lib/elswisser/tournaments.ex
@@ -136,9 +136,13 @@ defmodule Elswisser.Tournaments do
     Repo.all(from p in Player, where: p.id in ^player_ids)
   end
 
-  def calculate_length(players) do
-    ceil(Math.log2(length(players)))
+  def calculate_length(players) when is_list(players) do
+    players
+      |> length()
+      |> Math.log2()
+      |> ceil()
   end
+  def calculate_length(_), do: 0
 
   def ensure_rounds(len) do
     Enum.map(1..len, fn n -> %{number: n} end)


### PR DESCRIPTION
Got some issue with `player_ids` being `nil` when used in the ecto query.
