### PR TITLE
implement scores table, formatting check

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,5 +34,7 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-
       - name: Install dependencies
         run: mix deps.get
+      - name: Check Formatting
+        run: mix format --check-formatted
       - name: Run tests
         run: mix test

--- a/lib/elswisser/scores.ex
+++ b/lib/elswisser/scores.ex
@@ -16,6 +16,14 @@ defmodule Elswisser.Scores do
     |> tiebreaks()
   end
 
+  def with_players(scores, players) do
+    Enum.map(players, fn player -> Map.merge(player, scores[player.id]) end)
+    |> Enum.sort_by(fn r -> r.nblack end, :desc)
+    |> Enum.sort_by(fn r -> r.solkoff end, :desc)
+    |> Enum.sort_by(fn r -> r.modmed end, :desc)
+    |> Enum.sort_by(fn r -> r.score end, :desc)
+  end
+
   @doc """
   Given the struct representing a game + a round, build out all available
   scores, including tiebreak scores that can be calculated at this point. The
@@ -99,20 +107,21 @@ defmodule Elswisser.Scores do
   def modified_median(%Elswisser.Scores{} = v, scores) when is_map(scores) do
     opp_score = v.opponents
 
-    {min_score, max_score} = Enum.map(opp_score, fn opp -> scores[opp].score end)
+    {min_score, max_score} =
+      Enum.map(opp_score, fn opp -> scores[opp].score end)
       |> Enum.min_max()
 
     cond do
-      v.score > (length(v.opponents) / 2) ->
+      v.score > length(v.opponents) / 2 ->
         solkoff(v, scores) - min_score
-      v.score < (length(v.opponents) / 2) ->
+
+      v.score < length(v.opponents) / 2 ->
         solkoff(v, scores) - max_score
+
       true ->
         solkoff(v, scores) - (min_score + max_score)
     end
   end
-
-
 
   @doc """
   Caculate the "cumulative opposition" tiebreaker: sum the cumulative sum of the

--- a/lib/elswisser_web/components/tournaments/tournament.html.heex
+++ b/lib/elswisser_web/components/tournaments/tournament.html.heex
@@ -5,7 +5,7 @@
     <div class="col-span-2">
       <.sidenav tournament={@tournament} />
     </div>
-    <div class="col-span-8 mx-auto w-full p-4">
+    <div class="col-span-8 mx-auto w-full px-4">
       <%= @inner_content %>
     </div>
   </div>

--- a/lib/elswisser_web/controllers/round_html/show.html.heex
+++ b/lib/elswisser_web/controllers/round_html/show.html.heex
@@ -1,6 +1,8 @@
-<.header>
-  Round <%= @round.id %>
-</.header>
+<div class="pt-4">
+  <.header>
+    Round <%= @round.id %>
+  </.header>
+</div>
 
 <%= live_render(
   @conn,

--- a/lib/elswisser_web/controllers/tournament_controller.ex
+++ b/lib/elswisser_web/controllers/tournament_controller.ex
@@ -84,7 +84,7 @@ defmodule ElswisserWeb.TournamentController do
   def scores(conn, %{"tournament_id" => id}) do
     tournament = Tournaments.get_tournament_with_all!(id)
     games = Tournaments.get_all_games_in_tournament!(id)
-    scores = Scores.calculate(games)
+    scores = Scores.calculate(games) |> Scores.with_players(tournament.players)
 
     conn
     |> put_layout(html: {ElswisserWeb.TournamentLayouts, :tournament})

--- a/lib/elswisser_web/controllers/tournament_html.ex
+++ b/lib/elswisser_web/controllers/tournament_html.ex
@@ -25,4 +25,45 @@ defmodule ElswisserWeb.TournamentHTML do
   attr :action, :string, required: true
 
   def tournament_form(assigns)
+
+  attr :id, :string, required: true
+  attr :rows, :list, required: true
+
+  slot :col, required: true do
+    attr :label, :string
+    attr :center, :boolean
+    attr :bold, :boolean
+  end
+
+  def scores_table(assigns) do
+    ~H"""
+    <div class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
+      <table id={@id} class="w-[40rem] sm:w-full">
+        <thead class="text-sm text-left leading-4 text-zinc-500">
+          <tr>
+            <th
+              :for={col <- @col}
+              class={["p-0 pr-4 pb-2 font-normal", col[:center] && "text-center"]}
+            >
+              <%= col[:label] %>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          id={@id}
+          class="relative divide-y divide-zinc-100 border-t border-zinc-200 text-sm leading-6 text-zinc-700"
+        >
+          <tr :for={row <- @rows} class="group hover:bg-zinc-50">
+            <td :for={col <- @col} class={["relative p-0", col[:center] && "text-center"]}>
+              <div class="block py-1 pr-6">
+                <span class="absolute -inset-y-px right-0 -left-4 group-hover:bg-zinc-50 sm:rounded-l-xl" />
+                <span class="relative"><%= render_slot(col, row) %></span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    """
+  end
 end

--- a/lib/elswisser_web/controllers/tournament_html/scores.html.heex
+++ b/lib/elswisser_web/controllers/tournament_html/scores.html.heex
@@ -1,3 +1,14 @@
-<pre>
-  <%= @scores |> Jason.encode! |> Jason.Formatter.pretty_print() %>
-</pre>
+<div class="mx-auto max-w-2xl">
+  <div class="py-4">
+    <.header>Score Details</.header>
+  </div>
+
+  <.scores_table id="scores" rows={@scores}>
+    <:col :let={score} label="Name" bold><%= score.name %></:col>
+    <:col :let={score} label="Score" center><%= score.score %></:col>
+    <:col :let={score} label="Modified Median" center><%= score.modmed %></:col>
+    <:col :let={score} label="Solkoff" center><%= score.solkoff %></:col>
+    <:col :let={score} label="Cumulative of Opposition" center><%= score.cumulative_opp %></:col>
+    <:col :let={score} label="# Black Games" center><%= score.nblack %></:col>
+  </.scores_table>
+</div>

--- a/test/elswisser/rounds_test.exs
+++ b/test/elswisser/rounds_test.exs
@@ -42,6 +42,5 @@ defmodule Elswisser.RoundsTest do
       assert {:error, %Ecto.Changeset{}} = Rounds.update_round(round, @invalid_attrs)
       assert round == Rounds.get_round!(round.id)
     end
-
   end
 end

--- a/test/elswisser/scores_test.exs
+++ b/test/elswisser/scores_test.exs
@@ -9,106 +9,105 @@ defmodule Elswisser.ScoresTest do
     # player IDs are just their relative position in alphabetical order
     setup %{} do
       {:ok,
-        scores:
-          Elswisser.Scores.calculate([
-            %{
-              game: %Game{
-                white: 4,
-                black: 1,
-                result: -1
-              },
-              rnd: 1
-            },
-            %{
-              game: %Game{
-                white: 3,
-                black: 2,
-                result: -1
-              },
-              rnd: 1
-            },
-            %{
-              game: %Game{
-                white: 8,
-                black: 6,
-                result: 1
-              },
-              rnd: 1
-            },
-            %{
-              game: %Game{
-                white: 7,
-                black: 5,
-                result: 1
-              },
-              rnd: 1
-            },
-            %{
-              game: %Game{
-                white: 2,
-                black: 1,
-                result: 1
-              },
-              rnd: 2
-            },
-            %{
-              game: %Game{
-                white: 8,
-                black: 7,
-                result: -1
-              },
-              rnd: 2
-            },
-            %{
-              game: %Game{
-                white: 6,
-                black: 3,
-                result: -1
-              },
-              rnd: 2
-            },
-            %{
-              game: %Game{
-                white: 5,
-                black: 4,
-                result: -1
-              },
-              rnd: 2
-            },
-            %{
-              game: %Game{
-                white: 7,
-                black: 2,
-                result: 1
-              },
-              rnd: 3
-            },
-            %{
-              game: %Game{
-                white: 4,
-                black: 3,
-                result: 1
-              },
-              rnd: 3
-            },
-            %{
-              game: %Game{
-                white: 1,
-                black: 8,
-                result: -1
-              },
-              rnd: 3
-            },
-            %{
-              game: %Game{
-                white: 6,
-                black: 5,
-                result: -1
-              },
-              rnd: 3
-            }
-          ])
-    }
+       scores:
+         Elswisser.Scores.calculate([
+           %{
+             game: %Game{
+               white: 4,
+               black: 1,
+               result: -1
+             },
+             rnd: 1
+           },
+           %{
+             game: %Game{
+               white: 3,
+               black: 2,
+               result: -1
+             },
+             rnd: 1
+           },
+           %{
+             game: %Game{
+               white: 8,
+               black: 6,
+               result: 1
+             },
+             rnd: 1
+           },
+           %{
+             game: %Game{
+               white: 7,
+               black: 5,
+               result: 1
+             },
+             rnd: 1
+           },
+           %{
+             game: %Game{
+               white: 2,
+               black: 1,
+               result: 1
+             },
+             rnd: 2
+           },
+           %{
+             game: %Game{
+               white: 8,
+               black: 7,
+               result: -1
+             },
+             rnd: 2
+           },
+           %{
+             game: %Game{
+               white: 6,
+               black: 3,
+               result: -1
+             },
+             rnd: 2
+           },
+           %{
+             game: %Game{
+               white: 5,
+               black: 4,
+               result: -1
+             },
+             rnd: 2
+           },
+           %{
+             game: %Game{
+               white: 7,
+               black: 2,
+               result: 1
+             },
+             rnd: 3
+           },
+           %{
+             game: %Game{
+               white: 4,
+               black: 3,
+               result: 1
+             },
+             rnd: 3
+           },
+           %{
+             game: %Game{
+               white: 1,
+               black: 8,
+               result: -1
+             },
+             rnd: 3
+           },
+           %{
+             game: %Game{
+               white: 6,
+               black: 5,
+               result: -1
+             },
+             rnd: 3
+           }
+         ])}
     end
 
     test "creates an entry in the scores map for each directly", context do

--- a/test/elswisser/tournaments_test.exs
+++ b/test/elswisser/tournaments_test.exs
@@ -31,12 +31,10 @@ defmodule Elswisser.TournamentsTest do
       assert {:error, %Ecto.Changeset{}} = Tournaments.create_tournament(@invalid_attrs)
     end
 
-
     test "delete_tournament/1 deletes the tournament" do
       tournament = tournament_fixture()
       assert {:ok, %Tournament{}} = Tournaments.delete_tournament(tournament)
       assert_raise Ecto.NoResultsError, fn -> Tournaments.get_tournament!(tournament.id) end
     end
-
   end
 end

--- a/test/elswisser_web/controllers/tournament_controller_test.exs
+++ b/test/elswisser_web/controllers/tournament_controller_test.exs
@@ -3,7 +3,7 @@ defmodule ElswisserWeb.TournamentControllerTest do
 
   import Elswisser.TournamentsFixtures
 
-  @create_attrs %{name: "some name", player_ids: [1,2]}
+  @create_attrs %{name: "some name", player_ids: [1, 2]}
   @update_attrs %{name: "some updated name"}
   @invalid_attrs %{name: nil}
 

--- a/test/support/fixtures/tournaments_fixtures.ex
+++ b/test/support/fixtures/tournaments_fixtures.ex
@@ -15,7 +15,6 @@ defmodule Elswisser.TournamentsFixtures do
       })
       |> Elswisser.Tournaments.create_tournament()
 
-
     Elswisser.Tournaments.get_tournament!(tournament.id)
   end
 end


### PR DESCRIPTION
Fixes #12 

<img width="1512" alt="image" src="https://github.com/bsmithgall/elswisser/assets/1957344/d28dfd14-729d-4d14-aa15-9ebf916aa041">

This also adds a [format](https://hexdocs.pm/mix/main/Mix.Tasks.Format.html) check to the build process to make sure the code styles remain the same. Run `mix format` before committing or in a pre-commit hook to ensure the builds pass.
