### PR TITLE
render crosstable on crosstable page, standardize some layouts

### DIFF
--- a/lib/elswisser_web/components/tournaments.ex
+++ b/lib/elswisser_web/components/tournaments.ex
@@ -52,7 +52,7 @@ defmodule ElswisserWeb.TournamentLayouts do
 
   def navlink(assigns) do
     ~H"""
-    <div class="hover:bg-slate-300 cursor-pointer rounded-md p-1">
+    <div class="hover:bg-slate-300 cursor-pointer rounded-md p-1" phx-click={JS.navigate(@href)}>
       <.icon :if={@icon != nil} name={@icon} />
       <a href={@href}><%= @label %></a>
     </div>

--- a/lib/elswisser_web/components/tournaments/tournament.html.heex
+++ b/lib/elswisser_web/components/tournaments/tournament.html.heex
@@ -6,7 +6,9 @@
       <.sidenav tournament={@tournament} />
     </div>
     <div class="col-span-8 mx-auto w-full px-4">
-      <%= @inner_content %>
+      <div class="mx-auto max-w-4xl">
+        <%= @inner_content %>
+      </div>
     </div>
   </div>
 </main>

--- a/lib/elswisser_web/controllers/round_html/show.html.heex
+++ b/lib/elswisser_web/controllers/round_html/show.html.heex
@@ -1,8 +1,6 @@
-<div class="pt-4">
-  <.header>
-    Round <%= @round.id %>
-  </.header>
-</div>
+<.header class="pt-4">
+  Round <%= @round.id %>
+</.header>
 
 <%= live_render(
   @conn,

--- a/lib/elswisser_web/controllers/tournament_controller.ex
+++ b/lib/elswisser_web/controllers/tournament_controller.ex
@@ -76,15 +76,17 @@ defmodule ElswisserWeb.TournamentController do
     tournament = Tournaments.get_tournament_with_all!(id)
     games = Tournaments.get_all_games_in_tournament!(id)
 
+    scores = Scores.calculate(games) |> Scores.with_players(tournament.players) |> Scores.sort()
+
     conn
     |> put_layout(html: {ElswisserWeb.TournamentLayouts, :tournament})
-    |> render(:crosstable, tournament: tournament, games: games)
+    |> render(:crosstable, tournament: tournament, games: games, scores: scores)
   end
 
   def scores(conn, %{"tournament_id" => id}) do
     tournament = Tournaments.get_tournament_with_all!(id)
     games = Tournaments.get_all_games_in_tournament!(id)
-    scores = Scores.calculate(games) |> Scores.with_players(tournament.players)
+    scores = Scores.calculate(games) |> Scores.with_players(tournament.players) |> Scores.sort()
 
     conn
     |> put_layout(html: {ElswisserWeb.TournamentLayouts, :tournament})

--- a/lib/elswisser_web/controllers/tournament_html.ex
+++ b/lib/elswisser_web/controllers/tournament_html.ex
@@ -26,6 +26,9 @@ defmodule ElswisserWeb.TournamentHTML do
 
   def tournament_form(assigns)
 
+  @doc """
+  Renders the score detail table
+  """
   attr :id, :string, required: true
   attr :rows, :list, required: true
 
@@ -64,6 +67,31 @@ defmodule ElswisserWeb.TournamentHTML do
         </tbody>
       </table>
     </div>
+    """
+  end
+
+  attr :outer, :map, required: true
+  attr :inner, :map, required: true
+
+  def crosscell(assigns) do
+    result_idx = Enum.find_index(assigns.outer.opponents, fn o -> o == assigns.inner.id end)
+
+    result =
+      case is_nil(result_idx) do
+        true -> nil
+        false -> Enum.at(assigns.outer.results, result_idx)
+      end
+
+    assigns = assign(assigns, :is_self, assigns.outer.id == assigns.inner.id)
+    assigns = assign(assigns, :result, result)
+
+    ~H"""
+    <td class="border-r border-zinc-200 hover:bg-zinc-100">
+      <span :if={@is_self}><.icon name="hero-x-mark-solid" /></span>
+      <span :if={is_nil(@result)}></span>
+      <span :if={@result == 0.5}>&half;</span>
+      <span :if={@result != 0.5}><%= @result %></span>
+    </td>
     """
   end
 end

--- a/lib/elswisser_web/controllers/tournament_html/crosstable.html.heex
+++ b/lib/elswisser_web/controllers/tournament_html/crosstable.html.heex
@@ -1,1 +1,28 @@
-<table></table>
+<.header class="py-4">Score Crosstable</.header>
+
+<div class="overflow-y-auto px-4 sm:overflow-visible sm:px-0">
+  <table class="w-[40rem] sm:w-full text-center table-fixed">
+    <thead class="text-sm leading-4 text-zinc-500">
+      <tr>
+        <th class="border-r border-zinc-200"></th>
+        <%= for player <- @scores do %>
+          <th class="border-r border-zinc-200 p-1 break-words -rotate-12">
+            <%= player.name %>
+          </th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody class="relative divide-y divide-zinc-100 border-t border-b border-zinc-200 text-sm leading-6 text-zinc-700">
+      <%= for outer <- @scores do %>
+        <tr class="group">
+          <td class="text-sm text-zinc-500 border-r border-r-zinc-200 break-words">
+            <%= outer.name %>
+          </td>
+          <%= for inner <- @scores do %>
+            <.crosscell outer={outer} inner={inner} />
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/lib/elswisser_web/controllers/tournament_html/index.html.heex
+++ b/lib/elswisser_web/controllers/tournament_html/index.html.heex
@@ -1,4 +1,4 @@
-<.header>
+<.header class="py-4">
   Listing Tournaments
   <:actions>
     <.link href={~p"/tournaments/new"}>

--- a/lib/elswisser_web/controllers/tournament_html/scores.html.heex
+++ b/lib/elswisser_web/controllers/tournament_html/scores.html.heex
@@ -1,14 +1,10 @@
-<div class="mx-auto max-w-2xl">
-  <div class="py-4">
-    <.header>Score Details</.header>
-  </div>
+<.header class="py-4">Score Details</.header>
 
-  <.scores_table id="scores" rows={@scores}>
-    <:col :let={score} label="Name" bold><%= score.name %></:col>
-    <:col :let={score} label="Score" center><%= score.score %></:col>
-    <:col :let={score} label="Modified Median" center><%= score.modmed %></:col>
-    <:col :let={score} label="Solkoff" center><%= score.solkoff %></:col>
-    <:col :let={score} label="Cumulative of Opposition" center><%= score.cumulative_opp %></:col>
-    <:col :let={score} label="# Black Games" center><%= score.nblack %></:col>
-  </.scores_table>
-</div>
+<.scores_table id="scores" rows={@scores}>
+  <:col :let={score} label="Name" bold><%= score.name %></:col>
+  <:col :let={score} label="Score" center><%= score.score %></:col>
+  <:col :let={score} label="Modified Median" center><%= score.modmed %></:col>
+  <:col :let={score} label="Solkoff" center><%= score.solkoff %></:col>
+  <:col :let={score} label="Cumulative of Opposition" center><%= score.cumulative_opp %></:col>
+  <:col :let={score} label="# Black Games" center><%= score.nblack %></:col>
+</.scores_table>

--- a/lib/elswisser_web/controllers/tournament_html/show.html.heex
+++ b/lib/elswisser_web/controllers/tournament_html/show.html.heex
@@ -1,4 +1,4 @@
-<.header>
+<.header class="pt-4">
   Tournament <%= @tournament.id %>
   <:subtitle>This is a tournament record from your database.</:subtitle>
   <:actions>


### PR DESCRIPTION
- Add layout for crosstable (see screenshot). Not entirely sure how it will look with a huge number of players but for smaller tournaments it seems fine.
- Slightly modify the score calculation methods to make things a bit more elixir-idiomatic
- Standardize tournament view layouts a bit in terms of whitespace/padding/etc.

<img width="1512" alt="image" src="https://github.com/bsmithgall/elswisser/assets/1957344/7114b543-f33b-4634-9a9e-87ff19cebdba">

Fixes #13 