### PR TITLE
calculate ELO based on match results

### DIFF
--- a/lib/elswisser/players/elo.ex
+++ b/lib/elswisser/players/elo.ex
@@ -1,0 +1,28 @@
+defmodule Elswisser.Players.ELO do
+  @doc """
+  Recalculate ratings after a match
+  """
+  def recalculate(a, b, k, result) do
+    change = k * (to_score(result) - expected(a, b))
+    above_floor(a + change)
+  end
+
+  @doc """
+  Calculate expected change based on two players a and b. See: https://en.wikipedia.org/wiki/Elo_rating_system
+  """
+  def expected(a, b) when is_integer(a) and is_integer(b) do
+    1 / (1 + :math.pow(10, (b - a) / 400))
+  end
+
+  defp to_score(result) do
+    case result do
+      1 -> 1
+      0 -> 0.5
+      -1 -> 0
+    end
+  end
+
+  defp above_floor(adjusted) do
+    round(max(100, adjusted))
+  end
+end

--- a/lib/elswisser/players/player.ex
+++ b/lib/elswisser/players/player.ex
@@ -38,15 +38,17 @@ defmodule Elswisser.Players.Player do
   end
 
   def where_tournament_id(query, id) do
-    from [player: p] in query,
+    from([player: p] in query,
       join: t in assoc(p, :tournaments),
       as: :tournament,
       where: t.id == ^id
+    )
   end
 
   def where_not_matching(query, match_query) do
-    from [player: p] in query,
+    from([player: p] in query,
       where: p.id not in subquery(match_query)
+    )
   end
 
   def with_games(query) do
@@ -56,16 +58,14 @@ defmodule Elswisser.Players.Player do
   defp with_white_games(query) do
     from(p in query,
       left_join: w in assoc(p, :white_games),
-      as: :white_games,
-      preload: [white_games: w]
+      as: :white_games
     )
   end
 
   defp with_black_games(query) do
     from(p in query,
       left_join: b in assoc(p, :black_games),
-      as: :black_games,
-      preload: [black_games: b]
+      as: :black_games
     )
   end
 

--- a/test/elswisser/players_test.exs
+++ b/test/elswisser/players_test.exs
@@ -2,6 +2,7 @@ defmodule Elswisser.PlayersTest do
   use Elswisser.DataCase
 
   alias Elswisser.Players
+  alias Elswisser.Players.ELO
 
   describe "players" do
     alias Elswisser.Players.Player
@@ -56,6 +57,28 @@ defmodule Elswisser.PlayersTest do
     test "change_player/1 returns a player changeset" do
       player = player_fixture()
       assert %Ecto.Changeset{} = Players.change_player(player)
+    end
+  end
+
+  describe "ELO" do
+    test "1500 beats 1200 with K-factor of 40 yields +6" do
+      assert ELO.recalculate(1500, 1200, 40, 1) == 1500 + 6
+      assert ELO.recalculate(1200, 1500, 40, -1) == 1200 - 6
+    end
+
+    test "1400 draw with any K-factor yields no change" do
+      assert ELO.recalculate(1400, 1400, 40, 0) == 1400
+      assert ELO.recalculate(1400, 1400, 40, 0) == 1400
+    end
+
+    test "800 beats 1600 with K-factor of 40 yields +40" do
+      assert ELO.recalculate(800, 1600, 40, 1) == 800 + 40
+      assert ELO.recalculate(1600, 800, 40, -1) == 1600 - 40
+    end
+
+    test "rating cannot fall below 100" do
+      assert ELO.recalculate(100, 110, 40, -1) == 100
+      assert ELO.recalculate(110, 100, 40, 1) == 100 + 29
     end
   end
 end


### PR DESCRIPTION
Towards #42 but is missing the actual updating of the ELO records in the database. Need #43 to be fixed first so that this can happen in one shot during the round finalization.