### PR TITLE
Double elim redux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __pycache__
 
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+
+# ignore scratchpad
+/priv/scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,19 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y \ 
-  && apt-get install -y libstdc++6 openssl libncurses5 locales python3 \
-  && apt-get clean && \
-  rm -f /var/lib/apt/lists/*_*
+# see: https://github.com/nodesource/distributions
+
+RUN set -uex \
+  && apt-get update \
+  && apt-get install -y ca-certificates curl gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+  > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y libstdc++6 openssl libncurses5 locales python3 nodejs \
+  && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale
 RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -126,12 +126,7 @@ if config_env() == :prod do
     datasource_id: System.get_env("PROMEX_DATASOURCE_ID")
   }
 
-  config :elswisser, Elswisser.PromEx,
-    disabled: is_nil(System.get_env("PROMEX_ENABLED")),
-    manual_metrics_start_delay: :no_delay,
-    drop_metrics_groups: [],
-    grafana: Elswisser.PromEx.grafana_config(!is_nil(System.get_env("PROMEX_GRAFANA_ENABLED"))),
-    metrics_server: [
-      port: String.to_integer(System.get_env("METRICS_SERVER_PORT") || "4021")
-    ]
+  config :elswisser,
+         Elswisser.PromEx,
+         Elswisser.PromEx.config(not is_nil(System.get_env("PROMEX_ENABLED")))
 end

--- a/lib/elswisser/games/game.ex
+++ b/lib/elswisser/games/game.ex
@@ -7,6 +7,7 @@ defmodule Elswisser.Games.Game do
   alias Elswisser.Pairings.Bye
   alias Elswisser.Games.PgnProvider
   alias Elswisser.Games.Game
+  alias Elswisser.Players.Player
 
   schema "games" do
     field(:game_link, :string)
@@ -36,6 +37,7 @@ defmodule Elswisser.Games.Game do
       :black_id,
       :black_rating,
       :black_rating_change,
+      :black_seed,
       :finished_at,
       :game_link,
       :match_id,
@@ -45,7 +47,8 @@ defmodule Elswisser.Games.Game do
       :tournament_id,
       :white_id,
       :white_rating,
-      :white_rating_change
+      :white_rating_change,
+      :white_seed
     ])
     |> validate_required([:round_id, :tournament_id, :match_id])
     |> validate_different_players()
@@ -190,8 +193,49 @@ defmodule Elswisser.Games.Game do
     !(is_nil(game.result) and is_nil(game.finished_at))
   end
 
+  def take_seat(%Game{white_id: nil, black_id: nil}, %Player{} = player, player_seed) do
+    case Enum.random(0..1) do
+      0 ->
+        %{black_id: player.id, black_rating: player.rating, black_seed: player_seed}
+
+      1 ->
+        %{white_id: player.id, white_rating: player.rating, white_seed: player_seed}
+    end
+  end
+
+  def take_seat(%Game{black_id: nil, white_id: _}, %Player{} = player, player_seed) do
+    %{black_id: player.id, black_rating: player.rating, black_seed: player_seed}
+  end
+
+  def take_seat(%Game{white_id: nil, black_id: _}, %Player{} = player, player_seed) do
+    %{white_id: player.id, white_rating: player.rating, white_seed: player_seed}
+  end
+
+  def take_seat(
+        %Player{} = player_one,
+        player_one_seed,
+        %Player{} = player_two,
+        player_two_seed
+      ) do
+    %{
+      black_id: player_one.id,
+      black_rating: player_one.rating,
+      black_seed: player_one_seed,
+      white_id: player_two.id,
+      white_rating: player_two.rating,
+      white_seed: player_two_seed
+    }
+  end
+
+  def bye?(%Game{white: nil}), do: false
+  def bye?(%Game{black: nil}), do: false
+
   def bye?(%Game{} = game) do
     Bye.bye_player?(game.white) or Bye.bye_player?(game.black)
+  end
+
+  def playable?(%Game{} = game) do
+    not is_nil(game.white_id) and not is_nil(game.black_id)
   end
 
   def validate_game_link(changeset) do

--- a/lib/elswisser/games/game.ex
+++ b/lib/elswisser/games/game.ex
@@ -47,7 +47,7 @@ defmodule Elswisser.Games.Game do
       :white_rating,
       :white_rating_change
     ])
-    |> validate_required([:white_id, :black_id, :round_id, :tournament_id, :match_id])
+    |> validate_required([:round_id, :tournament_id, :match_id])
     |> validate_different_players()
     |> validate_game_link()
     |> unique_constraint(:unique_white_players, name: :games_white_id_round_id_unique_idx)
@@ -213,9 +213,10 @@ defmodule Elswisser.Games.Game do
     white_id = get_field(changeset, :white_id)
     black_id = get_field(changeset, :black_id)
 
-    case white_id == black_id do
-      false -> changeset
-      true -> add_error(changeset, :white_id, "A player cannot play themselves!")
+    cond do
+      is_nil(white_id) or is_nil(black_id) -> changeset
+      white_id == black_id -> add_error(changeset, :white_id, "A player cannot play themselves!")
+      true -> changeset
     end
   end
 end

--- a/lib/elswisser/matches.ex
+++ b/lib/elswisser/matches.ex
@@ -3,6 +3,14 @@ defmodule Elswisser.Matches do
   alias Elswisser.Repo
   alias Elswisser.Matches.Match
 
+  def get_by_id(ids) when is_list(ids) do
+    Match.from()
+    |> Match.where_id(ids)
+    |> Match.with_games()
+    |> Match.preload_games()
+    |> Repo.all()
+  end
+
   def create_match(attrs \\ %{}) do
     %Match{}
     |> Match.changeset(attrs)

--- a/lib/elswisser/matches/match.ex
+++ b/lib/elswisser/matches/match.ex
@@ -9,6 +9,11 @@ defmodule Elswisser.Matches.Match do
     field :board, :integer
     field :display_order, :integer
 
+    belongs_to(:winner_to, __MODULE__)
+    belongs_to(:loser_to, __MODULE__)
+
+    belongs_to(:winner, Elswisser.Players.Player)
+
     belongs_to(:round, Elswisser.Rounds.Round)
     has_many(:games, Elswisser.Games.Game)
 
@@ -16,9 +21,9 @@ defmodule Elswisser.Matches.Match do
   end
 
   @doc false
-  def changeset(match, attrs) do
+  def changeset(match, attrs \\ %{}) do
     match
-    |> cast(attrs, [:board, :display_order, :round_id])
+    |> cast(attrs, [:board, :display_order, :round_id, :loser_to_id, :winner_to_id])
     |> validate_required([:board, :display_order, :round_id])
   end
 

--- a/lib/elswisser/matches/match.ex
+++ b/lib/elswisser/matches/match.ex
@@ -2,6 +2,7 @@ defmodule Elswisser.Matches.Match do
   require Elswisser.Pairings.Bye
   alias Elswisser.Pairings.Bye
   use Ecto.Schema
+
   import Ecto.Changeset
   import Ecto.Query, warn: false
 
@@ -31,8 +32,18 @@ defmodule Elswisser.Matches.Match do
     from(m in __MODULE__, as: :match)
   end
 
-  def with_games(query) do
+  def where_id(query, ids) when is_list(ids) do
+    from([match: m] in query, where: m.id in ^ids)
+  end
+
+  def with_games(query), do: with_games(query, false)
+
+  def with_games(query, false) do
     from([match: m] in query, left_join: g in assoc(m, :games), as: :game)
+  end
+
+  def preload_games(query) do
+    from([game: g] in query, preload: [games: g])
   end
 
   def order_by_display_number(query) do
@@ -45,24 +56,31 @@ defmodule Elswisser.Matches.Match do
     Enum.at(match.games, 0)
   end
 
-  def winner(%__MODULE__{} = match) do
+  def result(%__MODULE__{} = match) do
     case match.games
          |> Enum.map(& &1.result)
          |> Enum.sum() do
       n when n > 0 ->
-        {hd(match.games).white, hd(match.games).white_seed}
+        {{hd(match.games).white, hd(match.games).white_seed},
+         {hd(match.games).black, hd(match.games).black_seed}}
 
       n when n < 0 ->
-        {hd(match.games).black, hd(match.games).black_seed}
+        {{hd(match.games).black, hd(match.games).black_seed},
+         {hd(match.games).white, hd(match.games).white_seed}}
 
       0 when Bye.bye_player?(hd(match.games).white) ->
-        {hd(match.games).black, hd(match.games).black_seed}
+        {{hd(match.games).black, hd(match.games).black_seed},
+         {hd(match.games).white, hd(match.games).white_seed}}
 
       0 when Bye.bye_player?(hd(match.games).black) ->
-        {hd(match.games).white, hd(match.games).white_seed}
+        {{hd(match.games).white, hd(match.games).white_seed},
+         {hd(match.games).black, hd(match.games).black_seed}}
 
       _ ->
-        nil
+        {nil, nil}
     end
   end
+
+  def winner(%__MODULE__{} = match), do: result(match) |> elem(0)
+  def loser(%__MODULE__{} = match), do: result(match) |> elem(1)
 end

--- a/lib/elswisser/pairings.ex
+++ b/lib/elswisser/pairings.ex
@@ -42,7 +42,7 @@ defmodule Elswisser.Pairings do
     scores
     |> partition()
     |> unique_possible_pairs(max_score)
-    |> Worker.pooled_call()
+    |> Worker.pooled_call(:swiss)
   end
 
   def partition(scores) when is_list(scores) do

--- a/lib/elswisser/pairings/bracket_pairing.ex
+++ b/lib/elswisser/pairings/bracket_pairing.ex
@@ -62,8 +62,8 @@ defmodule Elswisser.Pairings.BracketPairing do
     |> Enum.chunk_every(2)
     |> Enum.with_index()
     |> Enum.map(fn {[l, r], idx} ->
-      {one, one_seed} = Match.winner(l)
-      {two, two_seed} = Match.winner(r)
+      {{one, one_seed}, _} = Match.result(l)
+      {{two, two_seed}, _} = Match.result(r)
 
       %__MODULE__{
         player_one: one,
@@ -109,11 +109,11 @@ defmodule Elswisser.Pairings.BracketPairing do
 
   def to_game_params(%__MODULE__{} = pairing, round_id) do
     %{
-      white_id: pairing.player_one.id,
-      white_rating: pairing.player_one.rating,
+      white_id: if(pairing.player_one, do: pairing.player_one.id),
+      white_rating: if(pairing.player_one, do: pairing.player_one.rating),
       white_seed: pairing.player_one_seed,
-      black_id: pairing.player_two.id,
-      black_rating: pairing.player_two.rating,
+      black_id: if(pairing.player_two, do: pairing.player_two.id),
+      black_rating: if(pairing.player_two, do: pairing.player_two.rating),
       black_seed: pairing.player_two_seed,
       tournament_id: pairing.tournament_id,
       round_id: round_id,

--- a/lib/elswisser/pairings/bracket_pairing.ex
+++ b/lib/elswisser/pairings/bracket_pairing.ex
@@ -3,6 +3,7 @@ defmodule Elswisser.Pairings.BracketPairing do
 
   require Elswisser.Pairings.Bye
   alias Elswisser.Matches.Match
+  alias Elswisser.Games.Game
   alias Elswisser.Pairings.Seed
   alias Elswisser.Players.Player
   alias Elswisser.Pairings.Bye
@@ -83,6 +84,29 @@ defmodule Elswisser.Pairings.BracketPairing do
     next_power_of_two(length(n))
   end
 
+  def to_match_changeset(%__MODULE__{} = pairing, round_id, board \\ nil) do
+    %Match{}
+    |> Match.changeset(%{
+      display_order: display_order(board, pairing.display_order),
+      board: board(board, pairing.display_order),
+      round_id: round_id
+    })
+  end
+
+  def to_game_changeset(%__MODULE__{} = pairing, round_id) do
+    %Game{}
+    |> Game.changeset(%{
+      white_id: pairing.player_one.id,
+      white_rating: pairing.player_one.rating,
+      white_seed: pairing.player_one_seed,
+      black_id: pairing.player_two.id,
+      black_rating: pairing.player_two.rating,
+      black_seed: pairing.player_two_seed,
+      tournament_id: pairing.tournament_id,
+      round_id: round_id
+    })
+  end
+
   def to_game_params(%__MODULE__{} = pairing, round_id) do
     %{
       white_id: pairing.player_one.id,
@@ -122,5 +146,13 @@ defmodule Elswisser.Pairings.BracketPairing do
   defp find_seed(sorted, %Player{} = player) do
     idx = sorted |> Enum.find_index(&(&1 == player))
     idx + 1
+  end
+
+  defp board(board, display_order) do
+    if is_nil(board), do: display_order, else: board
+  end
+
+  defp display_order(board, display_order) do
+    if is_nil(display_order), do: board, else: display_order
   end
 end

--- a/lib/elswisser/pairings/bracket_worker.ex
+++ b/lib/elswisser/pairings/bracket_worker.ex
@@ -1,11 +1,20 @@
 defmodule Elswisser.Pairings.BracketWorker do
   def generate_bracket(players) do
     with {:ok, raw} <- generate_async(players),
-         {:ok, decoded} <- Jason.decode(raw) do
-      {:ok, decoded}
+         {:ok, decoded} <- Jason.decode(raw),
+         {:ok, matches, rounds} <- parse(decoded) do
+      {:ok, matches, rounds}
     else
       {:error, msg} -> {:error, msg}
     end
+  end
+
+  def parse(decoded) do
+    {
+      :ok,
+      decoded["matches"],
+      decoded["rounds"] |> Enum.map(fn {k, v} -> {String.to_integer(k), v} end) |> Enum.into(%{})
+    }
   end
 
   def generate_async(players) do

--- a/lib/elswisser/pairings/bracket_worker.ex
+++ b/lib/elswisser/pairings/bracket_worker.ex
@@ -1,0 +1,44 @@
+defmodule Elswisser.Pairings.BracketWorker do
+  def generate_bracket(players) do
+    with {:ok, raw} <- generate_async(players),
+         {:ok, decoded} <- Jason.decode(raw) do
+      {:ok, decoded}
+    else
+      {:error, msg} -> {:error, msg}
+    end
+  end
+
+  def generate_async(players) do
+    Task.async(fn ->
+      start(players |> Enum.map(& &1.id) |> Jason.encode!()) |> wait(nil)
+    end)
+    |> Task.await()
+  end
+
+  defp start(players) do
+    exe_path = System.find_executable("node")
+    script_path = [:code.priv_dir(:elswisser), "nodejs", "bracket.js"] |> Path.join()
+
+    Port.open({:spawn_executable, exe_path}, [
+      :stderr_to_stdout,
+      :binary,
+      :exit_status,
+      args: [script_path, players]
+    ])
+  end
+
+  defp wait(port, results) do
+    receive do
+      {port, {:data, data}} ->
+        wait(port, data)
+
+      {^port, {:exit_status, 0}} ->
+        {:ok, results}
+
+      {^port, {:exit_status, _}} ->
+        {:error, results}
+    after
+      5_000 -> {:error, :timeout}
+    end
+  end
+end

--- a/lib/elswisser/pairings/double_elimination.ex
+++ b/lib/elswisser/pairings/double_elimination.ex
@@ -1,0 +1,159 @@
+defmodule Elswisser.Pairings.DoubleElimination do
+  use Ecto.Schema
+
+  alias Elswisser.Pairings.BracketPairing
+  alias Elswisser.Repo
+  alias Elswisser.Rounds.Round
+  alias Elswisser.Pairings.BracketWorker
+  alias Elswisser.Tournaments.Tournament
+  alias Elswisser.Matches.Match
+
+  @primary_key false
+  embedded_schema do
+    field :round_number, :integer
+    field :winner_round, :integer
+    field :winner_match, :integer
+    field :loser_round, :integer
+    field :loser_match, :integer
+    embeds_one :pairing, BracketPairing
+  end
+
+  def create_all(%Tournament{} = tournament) do
+    players = Enum.sort_by(tournament.players, & &1.rating, :desc)
+
+    with {:ok, decoded} = BracketWorker.generate_bracket(players),
+         matches <- Enum.map(decoded, &parse(&1, players, tournament.id)),
+         {:ok, rounds_multi} <- make_round_multi(matches, tournament.id) |> Repo.transaction(),
+         {:ok, matches_and_games_multi} <-
+           make_game_match_multi(matches, rounds_multi) |> Repo.transaction(),
+         {:ok, _} <-
+           link_matches(matches, rounds_multi, matches_and_games_multi) |> Repo.transaction() do
+      {:ok, tournament.id}
+    else
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def parse(m, players, tournament_id) do
+    player_one_idx = Enum.find_index(players, &(&1.id == m["player1"]))
+    player_two_idx = Enum.find_index(players, &(&1.id == m["player2"]))
+
+    %__MODULE__{
+      round_number: m["round"],
+      winner_round: if(m["win"], do: m["win"]["round"]),
+      winner_match: if(m["win"], do: m["win"]["match"]),
+      loser_round: if(m["loss"], do: m["loss"]["round"]),
+      loser_match: if(m["loss"], do: m["loss"]["match"]),
+      pairing: %BracketPairing{
+        tournament_id: tournament_id,
+        player_one: if(not is_nil(player_one_idx), do: Enum.at(players, player_one_idx)),
+        player_one_seed: if(not is_nil(player_one_idx), do: player_one_idx + 1),
+        player_two: if(not is_nil(player_two_idx), do: Enum.at(players, player_two_idx)),
+        player_two_seed: if(not is_nil(player_two_idx), do: player_two_idx + 1),
+        display_order: m["match"]
+      }
+    }
+  end
+
+  def make_round_multi(matches, tournament_id) do
+    Enum.map(matches, & &1.round_number)
+    |> Enum.uniq()
+    |> Enum.reduce(Ecto.Multi.new(), fn round_number, acc ->
+      acc
+      |> Ecto.Multi.append(
+        Ecto.Multi.new()
+        |> Ecto.Multi.insert(
+          round_number,
+          %Round{}
+          |> Round.changeset(%{
+            number: round_number,
+            status: :playing,
+            tournament_id: tournament_id
+          })
+        )
+      )
+    end)
+  end
+
+  def make_game_match_multi(de_matches, rounds_multi) do
+    Enum.reduce(de_matches, Ecto.Multi.new(), fn de, acc ->
+      round_id = Map.get(rounds_multi, de.round_number).id
+
+      match_changeset = BracketPairing.to_match_changeset(de.pairing, round_id)
+      match_multi_id = {de.round_number, round_id, de.pairing.display_order}
+
+      match_multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.insert(match_multi_id, match_changeset)
+
+      match_multi =
+        if has_game?(de) do
+          Ecto.Multi.merge(match_multi, fn %{^match_multi_id => match} ->
+            Ecto.Multi.new()
+            |> Ecto.Multi.insert(
+              {:game, match_multi_id},
+              Ecto.build_assoc(
+                match,
+                :games,
+                BracketPairing.to_game_params(de.pairing, round_id)
+              )
+            )
+          end)
+        else
+          match_multi
+        end
+
+      acc |> Ecto.Multi.append(match_multi)
+    end)
+  end
+
+  def link_matches(de_matches, rounds_multi, matches_and_games_multi) do
+    Enum.reduce(de_matches, Ecto.Multi.new(), fn de, acc ->
+      current_match =
+        Map.get(
+          matches_and_games_multi,
+          {de.round_number, Map.get(rounds_multi, de.round_number).id, de.pairing.display_order}
+        )
+
+      next_matches =
+        %{}
+        |> Map.merge(
+          if(is_nil(de.winner_round),
+            do: %{},
+            else: %{
+              winner_to_id:
+                Map.get(
+                  matches_and_games_multi,
+                  {de.winner_round, Map.get(rounds_multi, de.winner_round).id, de.winner_match}
+                ).id
+            }
+          )
+        )
+        |> Map.merge(
+          if(is_nil(de.loser_round),
+            do: %{},
+            else: %{
+              loser_to_id:
+                Map.get(
+                  matches_and_games_multi,
+                  {de.loser_round, Map.get(rounds_multi, de.loser_round).id, de.loser_match}
+                ).id
+            }
+          )
+        )
+
+      acc
+      |> Ecto.Multi.append(
+        Ecto.Multi.new()
+        |> Ecto.Multi.update(
+          {:match, current_match.id},
+          Match.changeset(current_match, next_matches)
+        )
+      )
+    end)
+  end
+
+  defp has_game?(%__MODULE__{} = de) do
+    [de.pairing.player_one, de.pairing.player_two] |> Enum.any?()
+  end
+end

--- a/lib/elswisser/pairings/worker.ex
+++ b/lib/elswisser/pairings/worker.ex
@@ -13,7 +13,7 @@ defmodule Elswisser.Pairings.Worker do
   end
 
   def direct_call(pid, pairings) do
-    GenServer.call(pid, {:do_pairings, pairings})
+    GenServer.call(pid, {:swiss, pairings})
   end
 
   def pooled_call(pairings, :swiss) do

--- a/lib/elswisser/pairings/worker.ex
+++ b/lib/elswisser/pairings/worker.ex
@@ -16,11 +16,11 @@ defmodule Elswisser.Pairings.Worker do
     GenServer.call(pid, {:do_pairings, pairings})
   end
 
-  def pooled_call(pairings) do
+  def pooled_call(pairings, :swiss) do
     Task.async(fn ->
       :poolboy.transaction(
         :pairing_worker,
-        fn pid -> GenServer.call(pid, {:do_pairings, pairings}) end,
+        fn pid -> GenServer.call(pid, {:swiss, pairings}) end,
         @timeout
       )
     end)
@@ -38,7 +38,7 @@ defmodule Elswisser.Pairings.Worker do
   end
 
   @impl true
-  def handle_call({:do_pairings, pairings}, _from, pid) do
+  def handle_call({:swiss, pairings}, _from, pid) do
     result = :python.call(pid, :mwmatching, :maximum_weight_matching, [pairings])
     Logger.info("[#{__MODULE__}] Handled pairing request")
     {:reply, {:ok, result}, pid}

--- a/lib/elswisser/prom_ex.ex
+++ b/lib/elswisser/prom_ex.ex
@@ -87,6 +87,20 @@ defmodule Elswisser.PromEx do
     ]
   end
 
+  def config(true) do
+    [
+      disabled: false,
+      manual_metrics_start_delay: :no_delay,
+      drop_metrics_groups: [],
+      grafana: Elswisser.PromEx.grafana_config(!is_nil(System.get_env("PROMEX_GRAFANA_ENABLED"))),
+      metrics_server: [
+        port: String.to_integer(System.get_env("METRICS_SERVER_PORT") || "4021")
+      ]
+    ]
+  end
+
+  def config(false), do: [disabled: true]
+
   @doc """
   Only to be accessed during application boot
   """

--- a/lib/elswisser/rounds/round.ex
+++ b/lib/elswisser/rounds/round.ex
@@ -6,9 +6,14 @@ defmodule Elswisser.Rounds.Round do
   alias Elswisser.Tournaments.Tournament
   alias Elswisser.Matches.Match
 
+  @statuses ~w[pairing playing complete]a
+  @types ~w[winner loser championship none]a
+
   schema "rounds" do
     field(:number, :integer)
-    field(:status, Ecto.Enum, values: [:pairing, :playing, :complete])
+    field(:status, Ecto.Enum, values: @statuses)
+    field(:type, Ecto.Enum, values: @types, default: :none)
+    field(:display_name, :string)
 
     belongs_to(:tournament, Tournament)
     has_many(:matches, Match)
@@ -20,9 +25,18 @@ defmodule Elswisser.Rounds.Round do
   @doc false
   def changeset(round, attrs) do
     round
-    |> cast(attrs, [:number, :tournament_id, :status])
-    |> validate_required([:number, :tournament_id, :status])
+    |> cast(attrs, [:number, :tournament_id, :status, :type, :display_name])
+    |> add_display_name_if_missing()
+    |> validate_required([:number, :tournament_id, :status, :display_name])
   end
+
+  def add_display_name_if_missing(%Ecto.Changeset{changes: %{display_name: _}} = cs), do: cs
+
+  def add_display_name_if_missing(%Ecto.Changeset{data: %__MODULE__{display_name: nil}} = cs) do
+    cs |> put_change(:display_name, "Round #{get_field(cs, :number)}")
+  end
+
+  def add_display_name_if_missing(cs), do: cs
 
   def from() do
     from(r in Elswisser.Rounds.Round, as: :round)

--- a/lib/elswisser/rounds/round.ex
+++ b/lib/elswisser/rounds/round.ex
@@ -8,7 +8,6 @@ defmodule Elswisser.Rounds.Round do
 
   schema "rounds" do
     field(:number, :integer)
-    field(:expected_games, :integer, virtual: true)
     field(:status, Ecto.Enum, values: [:pairing, :playing, :complete])
 
     belongs_to(:tournament, Tournament)

--- a/lib/elswisser/tournaments.ex
+++ b/lib/elswisser/tournaments.ex
@@ -106,7 +106,7 @@ defmodule Elswisser.Tournaments do
   end
 
   def current_round(%Tournament{} = tournament) when not is_map_key(tournament, :rounds) do
-    %Round{number: 0}
+    %{number: 0}
   end
 
   @doc """

--- a/lib/elswisser/tournaments.ex
+++ b/lib/elswisser/tournaments.ex
@@ -272,7 +272,11 @@ defmodule Elswisser.Tournaments do
   end
 
   # everything is aleady created here
-  def create_next_round(%Tournament{type: :double_elimination} = tournament, _) do
+  def create_next_round(%Tournament{type: :double_elimination} = tournament, current_round_number) do
+    {:ok, _} =
+      Rounds.get_round_with_matches_and_players(tournament.id, current_round_number)
+      |> DoubleElimination.next_pairings()
+
     {:ok, %{tournament_id: tournament.id}}
   end
 

--- a/lib/elswisser/tournaments.ex
+++ b/lib/elswisser/tournaments.ex
@@ -5,6 +5,7 @@ defmodule Elswisser.Tournaments do
 
   import Ecto.Query, warn: false
   require Elswisser.Tournaments.Tournament
+  alias Elswisser.Pairings.DoubleElimination
   alias Elswisser.Tournaments.TournamentPlayer
   alias Elswisser.Matches.Match
   alias Elswisser.Matches
@@ -226,11 +227,7 @@ defmodule Elswisser.Tournaments do
     })
   end
 
-  def create_next_round(
-        %Tournament{type: type} = tournament,
-        0
-      )
-      when Tournament.is_knockout?(type) do
+  def create_next_round(%Tournament{type: :single_elimination} = tournament, 0) do
     {:ok, rnd} =
       Rounds.create_round(%{
         tournament_id: tournament.id,
@@ -248,10 +245,7 @@ defmodule Elswisser.Tournaments do
     {:ok, rnd}
   end
 
-  def create_next_round(
-        %Tournament{type: :single_elimination} = tournament,
-        current_round_number
-      ) do
+  def create_next_round(%Tournament{type: :single_elimination} = tournament, current_round_number) do
     {:ok, rnd} =
       Rounds.create_round(%{
         tournament_id: tournament.id,
@@ -269,6 +263,17 @@ defmodule Elswisser.Tournaments do
     # get all the matches and games from the just finished round
 
     {:ok, rnd}
+  end
+
+  def create_next_round(%Tournament{type: :double_elimination} = tournament, 0) do
+    {:ok, _} = DoubleElimination.create_all(tournament)
+
+    {:ok, %{tournament_id: tournament.id}}
+  end
+
+  # everything is aleady created here
+  def create_next_round(%Tournament{type: :double_elimination} = tournament, _) do
+    {:ok, %{tournament_id: tournament.id}}
   end
 
   def empty_changeset(%Tournament{} = tournament, attrs \\ %{}) do

--- a/lib/elswisser_web/components/brackets/double_elimination.ex
+++ b/lib/elswisser_web/components/brackets/double_elimination.ex
@@ -5,52 +5,29 @@ defmodule ElswisserWeb.Brackets.DoubleElimination do
   import ElswisserWeb.CoreComponents
   import ElswisserWeb.Brackets.Shared
 
-  attr(:length, :integer, required: true)
-  attr(:rounds, :list, required: true)
-  attr(:size, :integer, required: true)
+  attr(:tournament, Elswisser.Tournaments.Tournament, required: true)
 
   def bracket(assigns) do
-    {winners, losers} = Enum.split_with(1..assigns.length, &Integer.is_odd/1)
-
-    assigns =
-      assigns
-      |> assign(
-        :winners,
-        winners
-        |> Enum.with_index()
-        |> Enum.take_while(fn {_, idx} -> idx + 1 != length(winners) end)
-      )
-      |> assign(:losers, losers |> Enum.with_index())
-      |> assign(:grand_final, {List.last(winners), length(winners) - 1})
+    assigns = assigns |> assign(Enum.group_by(assigns.tournament.rounds, & &1.type))
 
     ~H"""
     <.header class="mt-4">Winners Bracket</.header>
     <div class="els__bracket flex text-sm text-zinc-700 overflow-x-auto">
-      <%= for {rnd_number, idx} <- @winners do %>
-        <.bracket_round
-          round={Enum.at(@rounds, rnd_number - 1)}
-          match_count={winner_match_count(idx + 1, @size)}
-        />
+      <%= for rnd <- @winner do %>
+        <.bracket_round round={rnd} />
       <% end %>
 
-      <.bracket_round round={Enum.at(@rounds, elem(@grand_final, 1))} match_count={1} />
+      <.bracket_round round={hd(@championship)} match_count={1} />
     </div>
 
     <hr />
 
     <.header class="mt-4">Losers Bracket</.header>
     <div class="els__bracket flex text-sm text-zinc-700 overflow-x-auto">
-      <%= for {rnd_number, idx} <- @losers do %>
-        <.bracket_round
-          round={Enum.at(@rounds, rnd_number)}
-          match_count={winner_match_count(idx + 1, @size)}
-        />
+      <%= for rnd <- @loser do %>
+        <.bracket_round round={rnd} />
       <% end %>
     </div>
     """
-  end
-
-  defp winner_match_count(round_number, player_count) do
-    div(player_count, Math.pow(2, round_number))
   end
 end

--- a/lib/elswisser_web/components/chess_components.ex
+++ b/lib/elswisser_web/components/chess_components.ex
@@ -73,6 +73,15 @@ defmodule ElswisserWeb.ChessComponents do
   attr(:rating, :integer, default: nil)
   attr(:bye, :boolean, default: false)
 
+  def player_result(%{player: nil} = assigns) do
+    ~H"""
+    <div class="col-span-2 grid grid-cols-2">
+      <div class="inline-block"><.seed :if={@show_seed} /><.square color={@color} /></div>
+      <span class="justify-self-end">—</span>
+    </div>
+    """
+  end
+
   def player_result(assigns) do
     ~H"""
     <div class="flex">
@@ -125,6 +134,12 @@ defmodule ElswisserWeb.ChessComponents do
     </span>
     """
   end
+
+  attr(:color, :atom, values: [:white, :black])
+  attr(:winner, :boolean, default: false)
+
+  def square(%{color: :white} = assigns), do: white_square(assigns)
+  def square(%{color: :black} = assigns), do: black_square(assigns)
 
   attr(:winner, :boolean, default: false)
 

--- a/lib/elswisser_web/components/tournaments/sidenav.html.heex
+++ b/lib/elswisser_web/components/tournaments/sidenav.html.heex
@@ -50,7 +50,7 @@
           do: ~p"/tournaments/#{rnd.tournament_id}/rounds/#{rnd}/pairings",
           else: ~p"/tournaments/#{rnd.tournament_id}/rounds/#{rnd}"
       }
-      label={"Round #{rnd.number}"}
+      label={rnd.display_name}
       icon={icon_by_round_status(rnd)}
       icon_class={icon_class_by_round_status(rnd)}
       active={@active == "round-#{rnd.id}"}

--- a/lib/elswisser_web/controllers/round_controller.ex
+++ b/lib/elswisser_web/controllers/round_controller.ex
@@ -31,14 +31,9 @@ defmodule ElswisserWeb.RoundController do
   def create(conn, %{"tournament_id" => tournament_id, "number" => number}) do
     case(Tournaments.create_next_round(conn.assigns[:tournament], number)) do
       {:ok, rnd} ->
-        redirect_to =
-          if conn.assigns[:tournament].type == :swiss,
-            do: ~p"/tournaments/#{rnd.tournament_id}/rounds/#{rnd.id}/pairings",
-            else: ~p"/tournaments/#{rnd.tournament_id}"
-
         conn
         |> put_flash(:info, "Round created successfully.")
-        |> redirect(to: redirect_to)
+        |> redirect(to: redirect_to(conn.assigns[:tournament].type, rnd))
 
       :finished ->
         conn
@@ -92,7 +87,7 @@ defmodule ElswisserWeb.RoundController do
         :info,
         "Round successfully completed. Pairings players for round #{next_round.number}."
       )
-      |> redirect(to: ~p"/tournaments/#{tournament_id}/rounds/#{next_round}/pairings")
+      |> redirect(to: redirect_to(conn.assigns[:tournament].type, rnd, next_round))
     else
       :finished ->
         conn
@@ -127,4 +122,14 @@ defmodule ElswisserWeb.RoundController do
     |> render("404.html")
     |> halt()
   end
+
+  defp redirect_to(:swiss, rnd),
+    do: ~p"/tournaments/#{rnd.tournament_id}/rounds/#{rnd.id}/pairings"
+
+  defp redirect_to(_, rnd), do: ~p"/tournaments/#{rnd.tournament_id}"
+
+  defp redirect_to(:swiss, rnd, next_round),
+    do: ~p"/tournaments/#{rnd.tournament_id}/rounds/#{next_round}/pairings"
+
+  defp redirect_to(_, rnd, _), do: ~p"/tournaments/#{rnd.tournament_id}"
 end

--- a/lib/elswisser_web/controllers/round_controller.ex
+++ b/lib/elswisser_web/controllers/round_controller.ex
@@ -85,7 +85,7 @@ defmodule ElswisserWeb.RoundController do
       conn
       |> put_flash(
         :info,
-        "Round successfully completed. Pairings players for round #{next_round.number}."
+        flash(conn.assigns[:tournament].type, next_round)
       )
       |> redirect(to: redirect_to(conn.assigns[:tournament].type, rnd, next_round))
     else
@@ -132,4 +132,9 @@ defmodule ElswisserWeb.RoundController do
     do: ~p"/tournaments/#{rnd.tournament_id}/rounds/#{next_round}/pairings"
 
   defp redirect_to(_, rnd, _), do: ~p"/tournaments/#{rnd.tournament_id}"
+
+  defp flash(:swiss, next_round),
+    do: "Round successfully completed. Pairings players for round #{next_round.number}."
+
+  defp flash(_, _), do: "Round successfully completed."
 end

--- a/lib/elswisser_web/controllers/tournaments/tournament_html/show_double_elimination.heex
+++ b/lib/elswisser_web/controllers/tournaments/tournament_html/show_double_elimination.heex
@@ -6,3 +6,8 @@
     </.link>
   </:actions>
 </.header>
+
+<ElswisserWeb.Brackets.DoubleElimination.bracket
+  :if={length(@tournament.rounds) > 0}
+  tournament={@tournament}
+/>

--- a/priv/nodejs/bracket.js
+++ b/priv/nodejs/bracket.js
@@ -347,7 +347,7 @@ function DoubleElimination(playerArray, startingRound = 1) {
     round: roundDiff,
     match: 1,
   };
-  return { matches, rounds: roundTypes(matches) };
+  return { matches, rounds: labelRounds(matches) };
 }
 
 const fillPattern = (matchCount, fillCount) => {
@@ -364,7 +364,7 @@ const fillPattern = (matchCount, fillCount) => {
     : y.concat(x);
 };
 
-const roundTypes = (matches) => {
+const labelRounds = (matches) => {
   const roundNumbers = matches.reduce((acc, match) => {
     if ((acc[match.round_type] || []).includes(match.round)) return acc;
 

--- a/priv/nodejs/bracket.js
+++ b/priv/nodejs/bracket.js
@@ -1,0 +1,371 @@
+/**
+ * DoubleElimination.js slightly modified from here:
+ * https://github.com/slashinfty/tournament-pairings/blob/main/src/DoubleElimination.ts
+ * Changes include:
+ *  - Adding a module.main handler for interop with Elswisser
+ *  - Changing types to only take a player array
+ *  - Some comments
+ *  - Prettier formatting
+ */
+
+function DoubleElimination(playerArray, startingRound = 1) {
+  const matches = [];
+
+  const exponent = Math.log2(playerArray.length);
+  const remainder = Math.round(2 ** exponent) % 2 ** Math.floor(exponent);
+
+  const bracket = [1, 4, 2, 3];
+
+  for (let i = 3; i <= Math.floor(exponent); i++) {
+    for (let j = 0; j < bracket.length; j += 2) {
+      bracket.splice(j + 1, 0, 2 ** i + 1 - bracket[j]);
+    }
+  }
+
+  // generate starting round
+  let round = startingRound;
+  if (remainder !== 0) {
+    for (let i = 0; i < remainder; i++) {
+      matches.push({
+        round: round,
+        match: i + 1,
+      });
+    }
+    round++;
+  }
+
+  // generate winner's bracket
+  let matchExponent = Math.floor(exponent) - 1;
+  let iterated = false;
+  do {
+    for (let i = 0; i < 2 ** matchExponent; i++) {
+      matches.push({
+        round: round,
+        match: i + 1,
+        player1: null,
+        player2: null,
+      });
+    }
+    if (!iterated) {
+      iterated = true;
+    } else {
+      matches
+        .filter((m) => m.round === round - 1)
+        .forEach(
+          (m) =>
+            (m.win = {
+              round: round,
+              match: Math.ceil(m.match / 2),
+            })
+        );
+    }
+    round++;
+    matchExponent--;
+  } while (round < startingRound + Math.ceil(exponent));
+
+  // populate first round of winner's bracket with players
+  const startRound = startingRound + (remainder === 0 ? 0 : 1);
+  matches
+    .filter((m) => m.round === startRound)
+    .forEach((m, i) => {
+      m.player1 = playerArray[bracket[2 * i] - 1];
+      m.player2 = playerArray[bracket[2 * i + 1] - 1];
+    });
+
+  // handle first round byes
+  if (remainder !== 0) {
+    matches
+      .filter((m) => m.round === startingRound)
+      .forEach((m, i) => {
+        m.player1 = playerArray[2 ** Math.floor(exponent) + i];
+        const p2 = playerArray[2 ** Math.floor(exponent) - i - 1];
+        const nextMatch = matches
+          .filter((n) => n.round === startingRound + 1)
+          .find((n) => n.player1 === p2 || n.player2 === p2);
+        if (nextMatch.player1 === p2) {
+          nextMatch.player1 = null;
+        } else {
+          nextMatch.player2 = null;
+        }
+        m.player2 = p2;
+        m.win = {
+          round: startingRound + 1,
+          match: nextMatch.match,
+        };
+      });
+  }
+
+  // championship round
+  matches.push({
+    round: round,
+    match: 1,
+    player1: null,
+    player2: null,
+  });
+  matches.find((m) => m.round === round - 1).win = {
+    round: round,
+    match: 1,
+  };
+
+  round++;
+
+  // generate pre-first round of loser's bracket with byes
+  const roundDiff = round - 1;
+  if (remainder !== 0) {
+    if (remainder <= 2 ** Math.floor(exponent) / 2) {
+      for (let i = 0; i < remainder; i++) {
+        matches.push({
+          round: round,
+          match: i + 1,
+          player1: null,
+          player2: null,
+        });
+      }
+      round++;
+    } else {
+      for (let i = 0; i < remainder - 2 ** (Math.floor(exponent) - 1); i++) {
+        matches.push({
+          round: round,
+          match: i + 1,
+          player1: null,
+          player2: null,
+        });
+      }
+      round++;
+      for (let i = 0; i < 2 ** (Math.floor(exponent) - 1); i++) {
+        matches.push({
+          round: round,
+          match: i + 1,
+          player1: null,
+          player2: null,
+        });
+      }
+      round++;
+    }
+  }
+
+  let loserExponent = Math.floor(exponent) - 2;
+  do {
+    for (let i = 0; i < 2; i++) {
+      for (let j = 0; j < 2 ** loserExponent; j++) {
+        matches.push({
+          round: round,
+          match: j + 1,
+          player1: null,
+          player2: null,
+        });
+      }
+      round++;
+    }
+    loserExponent--;
+  } while (loserExponent > -1);
+
+  let fillCount = 0;
+  let winRound = startingRound;
+  let loseRound = roundDiff + 1;
+  if (remainder === 0) {
+    const winMatches = matches.filter((m) => m.round === winRound);
+    const fill = fillPattern(winMatches.length, fillCount);
+    fillCount++;
+    let counter = 0;
+    matches
+      .filter((m) => m.round === loseRound)
+      .forEach((m) => {
+        for (let i = 0; i < 2; i++) {
+          const match = winMatches.find((m) => m.match === fill[counter]);
+          match.loss = {
+            round: m.round,
+            match: m.match,
+          };
+          counter++;
+        }
+      });
+    winRound++;
+    loseRound++;
+  } else if (remainder <= 2 ** Math.floor(exponent) / 2) {
+    let winMatches = matches.filter((m) => m.round === winRound);
+    let fill = fillPattern(winMatches.length, fillCount);
+    fillCount++;
+    matches
+      .filter((m) => m.round === loseRound)
+      .forEach((m, i) => {
+        const match = winMatches.find((m) => m.match === fill[i]);
+        match.loss = {
+          round: m.round,
+          match: m.match,
+        };
+      });
+    winRound++;
+    loseRound++;
+    winMatches = matches.filter((m) => m.round === winRound);
+    fill = fillPattern(winMatches.length, fillCount);
+    fillCount++;
+    let countA = 0;
+    let countB = 0;
+    let routeNumbers = matches
+      .filter(
+        (m) => m.round === 2 && (m.player1 === null || m.player2 === null)
+      )
+      .map((m) => Math.ceil(m.match / 2));
+    let routeCopy = [...routeNumbers];
+    matches
+      .filter((m) => m.round === loseRound)
+      .forEach((m) => {
+        for (let i = 0; i < 2; i++) {
+          const match = winMatches.find((m) => m.match === fill[countA]);
+          if (routeCopy.some((n) => n === m.match)) {
+            const lossMatch = matches.filter((x) => x.round === loseRound - 1)[
+              countB
+            ];
+            countB++;
+            match.loss = {
+              round: lossMatch.round,
+              match: lossMatch.match,
+            };
+            routeCopy.splice(routeCopy.indexOf(m.match), 1);
+          } else {
+            match.loss = {
+              round: m.round,
+              match: m.match,
+            };
+          }
+          countA++;
+        }
+      });
+    winRound++;
+    loseRound++;
+    matches
+      .filter((m) => m.round === roundDiff + 1)
+      .forEach((m, i) => {
+        const match = matches.find(
+          (x) => x.round === m.round + 1 && x.match === routeNumbers[i]
+        );
+        m.win = {
+          round: match.round,
+          match: match.match,
+        };
+      });
+  } else {
+    const winMatches = matches.filter((m) => m.round === winRound);
+    const loseMatchesA = matches.filter((m) => m.round === loseRound);
+    loseRound++;
+    const loseMatchesB = matches.filter((m) => m.round === loseRound);
+    const fill = fillPattern(winMatches.length, fillCount);
+    fillCount++;
+    let countA = 0;
+    let countB = 0;
+    let routeNumbers = matches
+      .filter((m) => m.round === 2 && m.player1 === null && m.player2 === null)
+      .map((m) => m.match);
+    loseMatchesB.forEach((m) => {
+      const winMatchA = winMatches.find((x) => x.match === fill[countA]);
+      if (routeNumbers.some((n) => n === m.match)) {
+        const lossMatch = loseMatchesA[countB];
+        winMatchA.loss = {
+          round: lossMatch.round,
+          match: lossMatch.match,
+        };
+        countA++;
+        countB++;
+        const winMatchB = winMatches.find((x) => x.match === fill[countA]);
+        winMatchB.loss = {
+          round: lossMatch.round,
+          match: lossMatch.match,
+        };
+      } else {
+        winMatchA.loss = {
+          round: m.round,
+          match: m.match,
+        };
+      }
+      countA++;
+    });
+    winRound++;
+    matches
+      .filter((m) => m.round === roundDiff + 1)
+      .forEach((m, i) => {
+        const match = matches.find(
+          (x) => x.round === m.round + 1 && x.match === routeNumbers[i]
+        );
+        m.win = {
+          round: match.round,
+          match: match.match,
+        };
+      });
+  }
+  let ffwd = 0;
+  for (let i = winRound; i < roundDiff; i++) {
+    let loseMatchesA = matches.filter(
+      (m) => m.round === loseRound - winRound + ffwd + i
+    );
+    const lostMatchesB = matches.filter(
+      (m) => m.round === loseRound - winRound + ffwd + i + 1
+    );
+    if (loseMatchesA.length === lostMatchesB.length) {
+      loseMatchesA = lostMatchesB;
+      ffwd++;
+    }
+    const winMatches = matches.filter((m) => m.round === i);
+    const fill = fillPattern(winMatches.length, fillCount);
+    fillCount++;
+    loseMatchesA.forEach((m, j) => {
+      const match = winMatches.find((m) => m.match === fill[j]);
+      match.loss = {
+        round: m.round,
+        match: m.match,
+      };
+    });
+  }
+  for (
+    let i = remainder === 0 ? roundDiff + 1 : roundDiff + 2;
+    i < matches.reduce((max, curr) => Math.max(max, curr.round), 0);
+    i++
+  ) {
+    const loseMatchesA = matches.filter((m) => m.round === i);
+    const loseMatchesB = matches.filter((m) => m.round === i + 1);
+    loseMatchesA.forEach((m, j) => {
+      const match =
+        loseMatchesA.length === loseMatchesB.length
+          ? loseMatchesB[j]
+          : loseMatchesB[Math.floor(j / 2)];
+      m.win = {
+        round: match.round,
+        match: match.match,
+      };
+    });
+  }
+  matches.filter(
+    (m) =>
+      m.round === matches.reduce((max, curr) => Math.max(max, curr.round), 0)
+  )[0].win = {
+    round: roundDiff,
+    match: 1,
+  };
+  return matches;
+}
+
+const fillPattern = (matchCount, fillCount) => {
+  const a = [...new Array(matchCount)].map((_, i) => i + 1);
+  const c = fillCount % 4;
+  const x = a.slice(0, a.length / 2);
+  const y = a.slice(a.length / 2);
+  return c === 0
+    ? a
+    : c === 1
+    ? a.reverse()
+    : c === 2
+    ? x.reverse().concat(y.reverse())
+    : y.concat(x);
+};
+
+if (require.main === module) {
+  if (process.argv.length !== 3) {
+    console.log("Unable to generate bracket -- no proc detected");
+    process.exit(1);
+  } else {
+    const playerArray = JSON.parse(process.argv[2]);
+    const b = DoubleElimination(playerArray);
+    console.log(JSON.stringify(b));
+    process.exit(0);
+  }
+}

--- a/priv/repo/migrations/20231214045333_add_match_self_references.exs
+++ b/priv/repo/migrations/20231214045333_add_match_self_references.exs
@@ -1,0 +1,12 @@
+defmodule Elswisser.Repo.Migrations.AddMatchSelfReferences do
+  use Ecto.Migration
+
+  def change do
+    alter table(:matches) do
+      add :winner_id, references(:players)
+
+      add :winner_to_id, references(:matches)
+      add :loser_to_id, references(:matches)
+    end
+  end
+end

--- a/priv/repo/migrations/20231215025849_add_round_types.exs
+++ b/priv/repo/migrations/20231215025849_add_round_types.exs
@@ -8,7 +8,9 @@ defmodule Elswisser.Repo.Migrations.AddRoundTypes do
     end
 
     execute """
-    UPDATE rounds SET display_name = (SELECT 'ROUND ' || number FROM rounds)
+    UPDATE rounds SET display_name = r.val
+    FROM (SELECT id, 'Round ' || number AS val FROM rounds) AS r
+    WHERE rounds.id = r.id
     """
   end
 

--- a/priv/repo/migrations/20231215025849_add_round_types.exs
+++ b/priv/repo/migrations/20231215025849_add_round_types.exs
@@ -1,0 +1,21 @@
+defmodule Elswisser.Repo.Migrations.AddRoundTypes do
+  use Ecto.Migration
+
+  def up do
+    alter table(:rounds) do
+      add :type, :string, default: "none"
+      add :display_name, :string
+    end
+
+    execute """
+    UPDATE rounds SET display_name = (SELECT 'ROUND ' || number FROM rounds)
+    """
+  end
+
+  def down do
+    alter table(:rounds) do
+      remove :type
+      remove :display_name
+    end
+  end
+end

--- a/test/elswisser/pairings/double_elimination_test.exs
+++ b/test/elswisser/pairings/double_elimination_test.exs
@@ -1,0 +1,25 @@
+defmodule Elswisser.Pairings.DoubleEliminationTest do
+  alias Elswisser.Tournaments
+  alias Elswisser.Pairings.DoubleElimination
+  use Elswisser.DataCase
+
+  import Elswisser.TournamentsFixtures
+
+  test "create_all/1 works as expected" do
+    tournament = tournament_with_players_fixture()
+
+    {:ok, id} = DoubleElimination.create_all(tournament)
+
+    tournament = Tournaments.get_tournament_with_all(id)
+
+    assert length(tournament.rounds) == 5
+
+    assert tournament.rounds |> Enum.frequencies_by(& &1.type) == %{
+             championship: 1,
+             loser: 2,
+             winner: 2
+           }
+
+    assert Enum.flat_map(tournament.rounds, fn r -> r.matches end) |> length() == 6
+  end
+end


### PR DESCRIPTION
Working double elimination tournaments. 

TODO before getting this deployed/set up:

- [x] Need to get a javascript runtime on to the Docker image (lol). Bun maybe since it's smaller?
- [ ] Need to add a "Active Matches" tab to the sidebar that shows pairing cards for all active matches across all rounds for the tournament. Starting to feel like players should be on matches instead of games, but that would be a huge amount of work to do, can probably punt it for now. Since everything is BO1 anyways, can just implement as "Active Games". Note this can happen later.
- [x] Visual cleanup can come later.