### PR TITLE
enable screenshotting of brackets

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -51,12 +51,15 @@ liveSocket.connect();
 window.liveSocket = liveSocket;
 
 window.addEventListener("elswisser:share-capture", async (el) => {
-  await shareCapture(el.target, () => {
-    const flash = document.getElementById(el.detail.flash_id);
-    if (flash) {
-      flash.removeAttribute("hidden");
-      flash.style = "";
-    }
+  await shareCapture({
+    elId: el.target,
+    onSuccess: () => {
+      const flash = document.getElementById(el.detail.flash_id);
+      if (flash) {
+        flash.removeAttribute("hidden");
+        flash.style = "";
+      }
+    },
   });
 });
 

--- a/assets/js/share-capture.js
+++ b/assets/js/share-capture.js
@@ -2,31 +2,57 @@ import * as htmlToImage from "html-to-image";
 
 export const ShareCaptureHook = {
   mounted() {
+    const elId = this.el.dataset.captureTarget ?? "pair-share";
+    const boundary = this.el.dataset.captureBounds ?? "clientBounds";
+    const childSelector = this.el.dataset.captureChildren ?? null;
+
     this.el.addEventListener("click", async (_evt) => {
-      await shareCapture("pair-share", () => {
-        this.liveSocket.main.isDead
-          ? alert("Successfully copied to Clipboard!")
-          : this.pushEvent("flash-copy-success");
+      await shareCapture({
+        elId,
+        boundary,
+        childSelector,
+        onSuccess: () => {
+          this.liveSocket.main.isDead
+            ? alert("Successfully copied to Clipboard!")
+            : this.pushEvent("flash-copy-success");
+        },
       });
     });
   },
 };
 
-export async function shareCapture(elId, onSuccess) {
+export async function shareCapture({
+  elId,
+  boundary,
+  childSelector,
+  onSuccess,
+}) {
   const el = elId instanceof HTMLElement ? elId : document.getElementById(elId);
 
+  let opts;
+
+  if (boundary === "complete") {
+    opts = getEntireSnapshotOpts(el);
+  } else if (boundary === "max-child") {
+    opts = getWidestChildSnapshotOpts(el, childSelector);
+  } else {
+    opts = getBoundingSnapshotOpts(el);
+  }
+
   try {
-    const shareResult = await generateShare(el);
+    if (boundary === "max-child") makeChildrenVisible(el, childSelector);
+    const shareResult = await generateShare(el, opts);
+    if (boundary === "max-child") ensureChildrenOverflow(el, childSelector);
 
     if (shareResult) onSuccess();
   } catch (err) {
     console.error(err);
+  } finally {
+    if (boundary === "max-child") ensureChildrenOverflow(el, childSelector);
   }
 }
 
-const generateShare = async (element) => {
-  const options = getSnapshotOptions(element);
-
+const generateShare = async (element, options) => {
   return "ClipboardItem" in window
     ? copyBlobToClipboard(element, options)
     : popBlobToWindow(element, options);
@@ -37,13 +63,44 @@ const generateShare = async (element) => {
  * @param {HTMLElement} element
  * @returns {htmlToImage}
  */
-const getSnapshotOptions = (element) => {
+const getBoundingSnapshotOpts = (element) => {
   const box = element.getBoundingClientRect();
 
   return {
     filter: (node) => !node.classList?.contains("js-screenshot-exclude"),
     height: box.height + 32,
     width: box.width + 32,
+    style: {
+      marginTop: 0,
+      padding: "0.75rem 1rem",
+      borderRadius: "0.35rem",
+    },
+  };
+};
+
+const getEntireSnapshotOpts = (element) => {
+  return {
+    filter: (node) => !node.classList?.contains("js-screenshot-exclude"),
+    height: element.scrollHeight + 32,
+    width: element.scrollWidth + 32,
+    style: {
+      marginTop: 0,
+      padding: "0.75rem 1rem",
+      borderRadius: "0.35rem",
+    },
+  };
+};
+
+const getWidestChildSnapshotOpts = (element, childSelector) => {
+  return {
+    filter: (node) => !node.classList?.contains("js-screenshot-exclude"),
+    height: element.scrollHeight + 32,
+    width:
+      Math.max(
+        ...[...element.querySelectorAll(childSelector)].map(
+          (e) => e.scrollWidth,
+        ),
+      ) + 32,
     style: {
       marginTop: 0,
       padding: "0.75rem 1rem",
@@ -71,8 +128,25 @@ const popBlobToWindow = async (element, options) => {
   w.document.write(
     `Your browser does not yet support ` +
       `<a target="_blank" href="https://caniuse.com/?search=ClipboardItem">ClipboardItem</a> :(. <br><br>` +
-      image.outerHTML
+      image.outerHTML,
   );
 
   return false;
+};
+
+const makeChildrenVisible = (el, childSelector) => {
+  el.classList.add("overflow-x-auto", "no-scrollbar");
+
+  el.querySelectorAll(childSelector).forEach((e) =>
+    e.classList.remove("overflow-x-auto"),
+  );
+};
+
+const ensureChildrenOverflow = (el, childSelector) => {
+  el.classList.remove("overflow-x-auto", "no-scrollbar");
+
+  el.querySelectorAll(childSelector).forEach((e) => {
+    e.classList.add("overflow-x-auto");
+    console.log(e);
+  });
 };

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -37,26 +37,41 @@ module.exports = {
     //     <div class="phx-click-loading:animate-ping">
     //
     plugin(({ addVariant }) =>
-      addVariant("phx-no-feedback", [".phx-no-feedback&", ".phx-no-feedback &"])
+      addVariant("phx-no-feedback", [
+        ".phx-no-feedback&",
+        ".phx-no-feedback &",
+      ]),
     ),
     plugin(({ addVariant }) =>
       addVariant("phx-click-loading", [
         ".phx-click-loading&",
         ".phx-click-loading &",
-      ])
+      ]),
     ),
     plugin(({ addVariant }) =>
       addVariant("phx-submit-loading", [
         ".phx-submit-loading&",
         ".phx-submit-loading &",
-      ])
+      ]),
     ),
     plugin(({ addVariant }) =>
       addVariant("phx-change-loading", [
         ".phx-change-loading&",
         ".phx-change-loading &",
-      ])
+      ]),
     ),
+
+    plugin(({ addUtilities }) => {
+      addUtilities({
+        ".no-scrollbar": {
+          "-ms-overflow-style": "none",
+          "scrollbar-width": "none",
+        },
+        ".no-scrollbar::-webkit-scrollbar": {
+          display: "none",
+        },
+      });
+    }),
 
     // Embeds Hero Icons (https://heroicons.com) into your app.css bundle
     // See your `CoreComponents.icon/1` for more information.
@@ -94,7 +109,7 @@ module.exports = {
             };
           },
         },
-        { values }
+        { values },
       );
     }),
     plugin(function ({ matchComponents, theme }) {
@@ -114,7 +129,7 @@ module.exports = {
               .replace(/\r?\n|\r/g, "");
             return {
               [`--icon-${name}`]: `url('data:image/svg+xml;utf8,${encodeURIComponent(
-                content
+                content,
               )}')`,
               "-webkit-mask": `var(--icon-${name})`,
               mask: `var(--icon-${name})`,
@@ -126,7 +141,7 @@ module.exports = {
             };
           },
         },
-        { values }
+        { values },
       );
     }),
     plugin(function ({ matchComponents, theme }) {
@@ -152,7 +167,7 @@ module.exports = {
 
             return {
               "background-image": `url('data:image/svg+xml;base64,${Buffer.from(
-                content
+                content,
               ).toString("base64")}')`,
               display: "inline-block",
               width: theme("spacing.5"),
@@ -161,7 +176,7 @@ module.exports = {
             };
           },
         },
-        { values }
+        { values },
       );
     }),
   ],

--- a/lib/elswisser_web/components/brackets/double_elimination.ex
+++ b/lib/elswisser_web/components/brackets/double_elimination.ex
@@ -12,27 +12,29 @@ defmodule ElswisserWeb.Brackets.DoubleElimination do
     assigns = assigns |> assign(Enum.group_by(assigns.tournament.rounds, & &1.type))
 
     ~H"""
-    <.header class="mt-4">Winners Bracket</.header>
-    <div class="my-4 flex text-sm text-zinc-700 overflow-x-auto h-full">
-      <%= for rnd <- @winner do %>
-        <.bracket_round round={rnd} />
-      <% end %>
-    </div>
+    <div id="bracket-boundary">
+      <.header class="mt-4">Winners Bracket</.header>
+      <div class="els__bracket my-4 flex text-sm text-zinc-700 overflow-x-auto h-full">
+        <%= for rnd <- @winner do %>
+          <.bracket_round round={rnd} />
+        <% end %>
+      </div>
 
-    <hr />
+      <hr />
 
-    <.header class="mt-4">Losers Bracket</.header>
-    <div class="my-4 flex text-sm text-zinc-700 overflow-x-auto h-full pb-6">
-      <%= for rnd <- @loser do %>
-        <.lower_round round={rnd} />
-      <% end %>
-    </div>
+      <.header class="mt-4">Losers Bracket</.header>
+      <div class="els__bracket my-4 flex text-sm text-zinc-700 overflow-x-auto h-full pb-6">
+        <%= for rnd <- @loser do %>
+          <.lower_round round={rnd} />
+        <% end %>
+      </div>
 
-    <hr />
+      <hr />
 
-    <.header class="mt-4">Championship</.header>
-    <div class="my-4 flex">
-      <.bracket_round round={hd(@championship)} grow={false} />
+      <.header class="mt-4">Championship</.header>
+      <div class="els__bracket my-4 flex">
+        <.bracket_round round={hd(@championship)} grow={false} />
+      </div>
     </div>
     """
   end

--- a/lib/elswisser_web/components/brackets/single_elimination.ex
+++ b/lib/elswisser_web/components/brackets/single_elimination.ex
@@ -9,7 +9,7 @@ defmodule ElswisserWeb.Brackets.SingleElimination do
 
   def bracket(assigns) do
     ~H"""
-    <div class="flex text-sm text-zinc-700 overflow-x-auto mt-8">
+    <div id="bracket-boundary" class="flex text-sm text-zinc-700 overflow-x-auto mt-8">
       <%= for idx <- 1..@length do %>
         <.bracket_round
           round={Enum.at(@rounds, idx - 1)}

--- a/lib/elswisser_web/controllers/tournaments/tournament_html/show_double_elimination.heex
+++ b/lib/elswisser_web/controllers/tournaments/tournament_html/show_double_elimination.heex
@@ -1,6 +1,15 @@
 <.header class="pt-4">
   <%= @tournament.name %>
   <:actions>
+    <.success_button
+      id="generate-pairing-svg-btn"
+      phx-hook="ShareCaptureHook"
+      data-capture-target="bracket-boundary"
+      data-capture-bounds="max-child"
+      data-capture-children=".els__bracket"
+    >
+      Screenshot bracket
+    </.success_button>
     <.link href={~p"/tournaments/#{@tournament}/edit"}>
       <.button>Edit tournament</.button>
     </.link>

--- a/lib/elswisser_web/controllers/tournaments/tournament_html/show_single_elimination.heex
+++ b/lib/elswisser_web/controllers/tournaments/tournament_html/show_single_elimination.heex
@@ -1,6 +1,14 @@
 <.header class="pt-4">
   <%= @tournament.name %>
   <:actions>
+    <.success_button
+      id="generate-pairing-svg-btn"
+      phx-hook="ShareCaptureHook"
+      data-capture-target="bracket-boundary"
+      data-capture-bounds="complete"
+    >
+      Screenshot bracket
+    </.success_button>
     <.link href={~p"/tournaments/#{@tournament}/edit"}>
       <.button>Edit tournament</.button>
     </.link>


### PR DESCRIPTION
- Tailwind `no-scrollbar` utility class
- Extend `pair-share` to include the ability to capture entire elements that have large scrollboxes
- Extend `pair-share` to allow for capturing elements where children are wider than the main element

Fixes #109 